### PR TITLE
Remove Mac OSX version check

### DIFF
--- a/qt-everywhere-opensource-src-4.8.5/src/corelib/global/qglobal.h
+++ b/qt-everywhere-opensource-src-4.8.5/src/corelib/global/qglobal.h
@@ -327,9 +327,6 @@ namespace QT_NAMESPACE {}
 #  if !defined(MAC_OS_X_VERSION_10_8)
 #       define MAC_OS_X_VERSION_10_8 MAC_OS_X_VERSION_10_7 + 1
 #  endif
-#  if (MAC_OS_X_VERSION_MAX_ALLOWED > MAC_OS_X_VERSION_10_8)
-#    warning "This version of Mac OS X is unsupported"
-#  endif
 #endif
 
 #ifdef __LSB_VERSION__


### PR DESCRIPTION
This PR removes the Qt check for Mac OS X version, which was stopping Gaffer from compiling on OS X 10.9 (Mavericks) or 10.10 (Yosemite)