### PR TITLE
Build scripts : Replace /bin/sh with /bin/bash

### DIFF
--- a/build/buildAlembic.sh
+++ b/build/buildAlembic.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/build/buildAll.sh
+++ b/build/buildAll.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/build/buildAppleseed.sh
+++ b/build/buildAppleseed.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/build/buildBoost.sh
+++ b/build/buildBoost.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/build/buildCortex.sh
+++ b/build/buildCortex.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/build/buildEXR.sh
+++ b/build/buildEXR.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/build/buildFonts.sh
+++ b/build/buildFonts.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/build/buildFreeType.sh
+++ b/build/buildFreeType.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/build/buildGLEW.sh
+++ b/build/buildGLEW.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/build/buildHDF5.sh
+++ b/build/buildHDF5.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/build/buildJPEG.sh
+++ b/build/buildJPEG.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/build/buildLLVM.sh
+++ b/build/buildLLVM.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/build/buildOCIO.sh
+++ b/build/buildOCIO.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/build/buildOIIO.sh
+++ b/build/buildOIIO.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/build/buildOSL.sh
+++ b/build/buildOSL.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/build/buildPNG.sh
+++ b/build/buildPNG.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/build/buildPackage.sh
+++ b/build/buildPackage.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 shopt -s nullglob

--- a/build/buildPyOpenGL.sh
+++ b/build/buildPyOpenGL.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/build/buildPySide.sh
+++ b/build/buildPySide.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/build/buildPython.sh
+++ b/build/buildPython.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/build/buildQt.sh
+++ b/build/buildQt.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/build/buildSubprocess32.sh
+++ b/build/buildSubprocess32.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/build/buildTBB.sh
+++ b/build/buildTBB.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/build/buildTIFF.sh
+++ b/build/buildTIFF.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/build/buildXerces.sh
+++ b/build/buildXerces.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 


### PR DESCRIPTION
I was trying to do my own build, and was getting errors. Turned out it was because I was in TCSH (don't ask!) and /bin/sh was using the system shell, whereas the build scripts required bash.